### PR TITLE
Modify the header in energies.train.process, and energies.test.process

### DIFF
--- a/src/train.f90
+++ b/src/train.f90
@@ -1318,8 +1318,8 @@ contains !=============================================================!
     u_sav = io_unit()
 
     ! file header with column description
-    header = "#  Ref(eV)        ANN(eV)      #atoms  Ref(eV/atom)" &
-             // "   ANN(eV/atom) Ref-ANN(eV/atom)    ANN error"
+    header = "  Ref(eV)        ANN(eV)      #atoms  Ref(eV/atom)" &
+             // "   ANN(eV/atom) Ref-ANN(eV/atom)    ANN-error"
     frmt = '(2x,"#",A' // trim(io_adjustl(TYPELEN)) // ')'
     write(str, frmt) ts_trn%typeName(1)
     header = trim(header) // " " // trim(str)
@@ -1327,7 +1327,7 @@ contains !=============================================================!
        write(str, frmt) ts_trn%typeName(itype)
        header = trim(header) // trim(str)
     end do
-    header = trim(header) // "    Path of input file"
+    header = trim(header) // "    Path-of-input-file"
 
     ! training set
     fname = 'energies.train.' // trim(io_adjustl(ppRank))


### PR DESCRIPTION
This modification removes the leading #, and removes spaces in the column
headings. This makes it easy to load these files into Pandas with column names.

```
#+BEGIN_SRC ipython
import pandas as pd

train = pd.read_csv('energies.train.0', delim_whitespace=True)
test = pd.read_csv('energies.test.0', delim_whitespace=True)
print(train.keys())
#+END_SRC

#+RESULTS:
:RESULTS:
# Out[1]:
# output
: Index(['Ref(eV)', 'ANN(eV)', '#atoms', 'Ref(eV/atom)', 'ANN(eV/atom)',
:        'Ref-ANN(eV/atom)', 'ANN-error', '#Ti', '#O', 'Path-of-input-file'],
:       dtype='object')
: 
:END:
```