### PR TITLE
Two fixes

### DIFF
--- a/src/ext/lclist.f90
+++ b/src/ext/lclist.f90
@@ -396,6 +396,7 @@ contains
     integer                                           :: iat, iT
     double precision                                  :: Rc, Rc2, dist2
     double precision, dimension(3)                    :: coo2, cart
+    integer                                           :: itype_
 
     if (.not. isInit) then
        write(0,*) "Error: module not initialized in `nbdist'."
@@ -412,6 +413,8 @@ contains
        stop
     end if
 
+    itype_ = 99999 ! absurd value to avoid GNU segfaults when itype is not present
+    if (present(itype)) itype_ = itype
     if (present(stat)) stat = 0
     if (present(r_cut)) then
        Rc = r_cut
@@ -429,7 +432,7 @@ contains
     ! (2) check distance do the periodic images of the central atom:
 
     nnb_tot = 0
-    if ( (.not. present(itype)) .or. (atomType(iatom) == itype)) then
+    if ( (.not. present(itype)) .or. (atomType(iatom) == itype_)) then
        do iT = 1, nTvecs
           cart(1:3) = matmul(latticeVec, dble(Tvec(1:3,iT)))
           dist2 = sum(cart*cart)
@@ -456,7 +459,7 @@ contains
 
     do inb = 1, nnb2
        iat = nblist_loc(inb)
-       if ( present(itype) .and. (atomType(iat) /= itype)) cycle
+       if ( present(itype) .and. (atomType(iat) /= itype_)) cycle
        ! in home unit cell:
        cart(1:3) = cooLatt(1:3,iat) - cooLatt(1:3,iatom)
        cart(1:3) = matmul(latticeVec, cart(1:3))
@@ -533,6 +536,7 @@ contains
     double precision                         :: Rc, Rc2, dist2
     double precision, dimension(3)           :: coo1, coo2, cart
     integer                                  :: nblist_stat
+    integer                                  :: itype_
 
     if (.not. isInit) then
        write(0,*) "Error: module not initialized in `nbdist'."
@@ -549,6 +553,8 @@ contains
        stop
     end if
 
+    itype_ = 99999 ! absurd value to avoid GNU segfaults when itype is not present
+    if (present(itype)) itype_ = itype
     if (present(stat)) stat = 0
     if (present(r_cut)) then
        Rc = r_cut
@@ -575,7 +581,7 @@ contains
     ! (2) check distance do the periodic images of the central atom:
 
     nnb_tot = 0
-    if ( (.not. present(itype)) .or. (atomType(iatom) == itype)) then
+    if ( (.not. present(itype)) .or. (atomType(iatom) == itype_)) then
        do iT = 1, nTvecs
           cart(1:3) = matmul(latticeVec, dble(Tvec(1:3,iT)))
           dist2 = sum(cart*cart)
@@ -608,7 +614,7 @@ contains
 
     do inb = 1, nnb2
        iat = nblist_loc(inb)
-       if ( present(itype) .and. (atomType(iat) /= itype)) cycle
+       if ( present(itype) .and. (atomType(iat) /= itype_)) cycle
        ! in home unit cell:
        coo2(1:3) = matmul(latticeVec, cooLatt(1:3,iat))
        cart(1:3) = coo2(1:3) - coo1(1:3)

--- a/src/makefiles/Makefile.gfortran92_mkl_serial
+++ b/src/makefiles/Makefile.gfortran92_mkl_serial
@@ -1,0 +1,45 @@
+#-*- mode: makefile -*-
+#-----------------------------------------------------------------------
+#                    GNU Fortran Compiler + MPI
+#-----------------------------------------------------------------------
+#+ This file is part of the AENET package.
+#+
+#+ Copyright (C) 2012-2018 Nongnuch Artrith and Alexander Urban
+#+
+#+ This Source Code Form is subject to the terms of the Mozilla Public
+#+ License, v. 2.0. If a copy of the MPL was not distributed with this
+#+ file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#+
+#+ This program is distributed in the hope that it will be useful, but
+#+ WITHOUT ANY WARRANTY; without even the implied warranty of
+#+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#+ Mozilla Public License, v. 2.0, for more details.
+#-----------------------------------------------------------------------
+# 2015-05-26 Alexander Urban (AU) and Nongnuch Artrith (NA)
+#-----------------------------------------------------------------------
+
+SUFFIX   = gfortran_mkl_serial
+
+FC       = gfortran -c
+LD       = gfortran
+DEBUG    = -fno-frontend-optimize -g
+FCFLAGS  = -O2 -pedantic -fexternal-blas $(DEBUG)
+LDFLAGS  = $(DEBUG)
+NUMLIB   = -Wl,--start-group \
+           $(MKLROOT)/lib/intel64/libmkl_intel_lp64.a \
+           $(MKLROOT)/lib/intel64/libmkl_core.a \
+           $(MKLROOT)/lib/intel64/libmkl_sequential.a \
+           -Wl,--end-group -lpthread -lm -ldl
+
+CC       = gcc -c
+CCFLAGS  =
+
+# linker for C-interoperable library (gcc & gfortran)
+LIBLD    = gcc
+LIBFLAGS = -shared
+LIBLIB   = -lgfortran
+
+AR       = ar
+ARFLAGS  = -crusv
+
+include ./Makefile.inc


### PR DESCRIPTION
I faced three problems when trying to run aenet with my inputs. This PR fixes two of them, the third will come in a different PR.

1. GNU Fortran v9.2 crashed with 'internal compiler error' owing to this problem: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=92321#c3 . Solution is posted in the same thread. I added a makefile to generate the serial code with GNU+MKL. Can be easily generalized to the other cases.
2. The binaries produced by GNU 9.2 segfault because of incorrect if statements that check an optional variable also when this is not passed as input. Fixed in `lclist.f90`, there might be other similar problems elsewhere, but this was enough to get `predict.x` running.