### PR TITLE
Fixed reference to optional argument rec that caused segfault 

### DIFF
--- a/src/trainset.f90
+++ b/src/trainset.f90
@@ -298,8 +298,12 @@ contains
     call ts_assert_init(ts)
     call ts_assert_readmode(ts)
 
-    if (present(rec) .and. (rec > 0)) then
-       irec = rec - 1
+    if (present(rec)) then
+       if (rec > 0) then
+          irec = rec - 1
+       else
+          irec = 0
+       endif
     else
        irec = 0
     end if


### PR DESCRIPTION
When using ifx (Intel's OneAPI Fortran; I'm using the newest 2025.1.0 version), train.x dies with segmentation fault upon execution. This seems to be due to optional argument "rec" being referenced at line 301 of trainset.f90 (rec > 0) even when the subroutine is called without this argument. Looks like a bug that was overlooked because of how most other compilers handle optional arguments. This pull request is a proposed fix for this issue.